### PR TITLE
Fix/blockstore write

### DIFF
--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -5,6 +5,7 @@ package blockstore
 
 import (
 	"fmt"
+	"github.com/google/renameio/v2"
 	"io/ioutil"
 	"math/big"
 	"os"
@@ -65,7 +66,7 @@ func (b *Blockstore) StoreBlock(block *big.Int) error {
 
 	// Write bytes to file
 	data := []byte(block.String())
-	err := ioutil.WriteFile(b.fullPath, data, 0600)
+	err := renameio.WriteFile(b.fullPath, data, 0600)
 	if err != nil {
 		return err
 	}

--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -4,7 +4,6 @@
 package blockstore
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -56,10 +55,6 @@ func NewBlockstore(path string, chain msg.ChainId, relayer string) (*Blockstore,
 
 // StoreBlock writes the block number to disk.
 func (b *Blockstore) StoreBlock(block *big.Int) error {
-	if block == nil {
-		return errors.New("storing empty string will lead to Blockstore corruption")
-	}
-
 	// Create dir if it does not exist
 	if _, err := os.Stat(b.path); os.IsNotExist(err) {
 		errr := os.MkdirAll(b.path, os.ModePerm)

--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -4,6 +4,7 @@
 package blockstore
 
 import (
+	"errors"
 	"fmt"
 	"github.com/google/renameio/v2"
 	"io/ioutil"
@@ -87,6 +88,9 @@ func (b *Blockstore) TryLoadLatestBlock() (*big.Int, error) {
 			return nil, err
 		}
 		block, _ := big.NewInt(0).SetString(string(dat), 10)
+		if block == nil {
+			return nil, errors.New("block number cannot be nil")
+		}
 		return block, nil
 	}
 	// Otherwise just return 0

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
+github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=
 github.com/gtank/merlin v0.1.1 h1:eQ90iG7K9pOhtereWsmyRJ6RAwcP4tHTDBHXNg+u5is=
 github.com/gtank/merlin v0.1.1/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=


### PR DESCRIPTION
1. Revert the previous fix as the reason for the issue is different.
2. The fix prevents storing empty strings in the block store by making `WriteFile` atomic.
3. Handle the error in case the issue persists after the fix

Fixes https://www.notion.so/cere/Bridge-Block-store-is-corrupted-e67cd80c93a043a0857f1de35d7b57bb#0d3bc56e70234de7ad778d35c4a6f27a
